### PR TITLE
Skip unsafe property access

### DIFF
--- a/build/stringifier.js
+++ b/build/stringifier.js
@@ -570,6 +570,28 @@ function allowedKeys (orderedWhiteList) {
     };
 }
 
+function safeKeys () {
+    return function (next) {
+        return function (acc, x) {
+            if (typeName(x) !== 'Array') {
+                acc.context.keys = acc.context.keys.filter(function (propKey) {
+                    // Error handling for unsafe property access.
+                    // For example, on PhantomJS,
+                    // accessing HTMLInputElement.selectionEnd causes TypeError
+                    try {
+                        var val = x[propKey];
+                        return true;
+                    } catch (e) {
+                        // skip unsafe key
+                        return false;
+                    }
+                });
+            }
+            return next(acc, x);
+        };
+    };
+}
+
 function when (guard, then) {
     return function (next) {
         return function (acc, x) {
@@ -785,6 +807,7 @@ module.exports = {
         compose: compose,
         when: when,
         allowedKeys: allowedKeys,
+        safeKeys: safeKeys,
         filter: filter,
         iterate: iterate,
         end: end
@@ -840,6 +863,7 @@ module.exports = {
             constructorName(),
             decorateObject(),
             allowedKeys(orderedWhiteList),
+            safeKeys(),
             filter(predicate),
             iterate()
         );

--- a/strategies.js
+++ b/strategies.js
@@ -89,6 +89,28 @@ function allowedKeys (orderedWhiteList) {
     };
 }
 
+function safeKeys () {
+    return function (next) {
+        return function (acc, x) {
+            if (typeName(x) !== 'Array') {
+                acc.context.keys = acc.context.keys.filter(function (propKey) {
+                    // Error handling for unsafe property access.
+                    // For example, on PhantomJS,
+                    // accessing HTMLInputElement.selectionEnd causes TypeError
+                    try {
+                        var val = x[propKey];
+                        return true;
+                    } catch (e) {
+                        // skip unsafe key
+                        return false;
+                    }
+                });
+            }
+            return next(acc, x);
+        };
+    };
+}
+
 function when (guard, then) {
     return function (next) {
         return function (acc, x) {
@@ -304,6 +326,7 @@ module.exports = {
         compose: compose,
         when: when,
         allowedKeys: allowedKeys,
+        safeKeys: safeKeys,
         filter: filter,
         iterate: iterate,
         end: end
@@ -359,6 +382,7 @@ module.exports = {
             constructorName(),
             decorateObject(),
             allowedKeys(orderedWhiteList),
+            safeKeys(),
             filter(predicate),
             iterate()
         );

--- a/test/runtime_type_error_test.js
+++ b/test/runtime_type_error_test.js
@@ -1,0 +1,27 @@
+(function (root, factory) {
+    'use strict';
+    if (typeof define === 'function' && define.amd) {
+        define(['stringifier', 'assert'], factory);
+    } else if (typeof exports === 'object') {
+        factory(require('..'), require('assert'));
+    } else {
+        factory(root.stringifier, root.assert);
+    }
+}(this, function (
+    stringifier,
+    assert
+) {
+
+var stringify = stringifier.stringify;
+
+if (typeof document !== 'undefined' && typeof document.getElementById === 'function') {
+    describe('in case of runtime TypeError', function () {
+        it('stringifying HTMLInputElement', function () {
+            var input = document.getElementById("confirmation");
+            var str = stringify(input, {maxDepth: 1});
+            assert.equal(str, '');
+        });
+    });
+}
+
+}));

--- a/test/runtime_type_error_test.js
+++ b/test/runtime_type_error_test.js
@@ -19,7 +19,9 @@ if (typeof document !== 'undefined' && typeof document.getElementById === 'funct
         it('stringifying HTMLInputElement', function () {
             var input = document.getElementById("confirmation");
             var str = stringify(input, {maxDepth: 1});
-            assert.equal(str, '');
+            assert(/^HTMLInputElement/.test(str));
+            assert(/defaultChecked\:false/.test(str));
+            assert(/multiple\:false/.test(str));
         });
     });
 }

--- a/test/test-amd.html
+++ b/test/test-amd.html
@@ -9,6 +9,11 @@
   </head>
   <body>
     <div id="mocha"></div>
+    <div id="sandbox">
+      <form action="#" method="POST">
+        <input type="checkbox" name="confirmation" id="confirmation"/>Confirmation
+      </form>
+    </div>
     <script type="text/javascript" src="../bower_components/mocha/mocha.js"></script>
     <script type="text/javascript">
       mocha.setup('bdd');
@@ -19,7 +24,8 @@
       require([
         "./array_and_object_test.js",
         "./customization_test.js",
-        "./various_types_test.js"
+        "./various_types_test.js",
+        "./runtime_type_error_test.js"
       ], function() {
         mocha.checkLeaks();
         if (window.mochaPhantomJS) {

--- a/test/test-browser.html
+++ b/test/test-browser.html
@@ -9,6 +9,11 @@
   </head>
   <body>
     <div id="mocha"></div>
+    <div id="sandbox">
+      <form action="#" method="POST">
+        <input type="checkbox" name="confirmation" id="confirmation"/>Confirmation
+      </form>
+    </div>
     <script type="text/javascript" src="../bower_components/es5-shim/es5-shim.js"></script>
     <script type="text/javascript" src="../bower_components/mocha/mocha.js"></script>
     <script type="text/javascript">
@@ -20,6 +25,7 @@
     <script type="text/javascript" src="./array_and_object_test.js"></script>
     <script type="text/javascript" src="./customization_test.js"></script>
     <script type="text/javascript" src="./various_types_test.js"></script>
+    <script type="text/javascript" src="./runtime_type_error_test.js"></script>
     <script type="text/javascript">
       mocha.checkLeaks();
       if (window.mochaPhantomJS) {


### PR DESCRIPTION
For example, on PhantomJS, iterating `HTMLInputElement` causes TypeError on accessing some (maybe hidden?) properties such as `selectionEnd`.

Need to skip them.

- [x] add bug reproduction testcase
- [x] fix it
