### PR TITLE
feat: support BigInt values

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,7 @@ function defaultHandlers () {
         'string': s.json(),
         'boolean': s.json(),
         'number': s.number(),
+        'bigint': s.bigint(),
         'symbol': s.toStr(),
         'RegExp': s.toStr(),
         'String': s.newLike(),
@@ -487,6 +488,18 @@ var stringify = stringifier({
 });
 assert(stringify([NaN, 0, Infinity, -0, -Infinity]) === '[NaN,0,Infinity,0,-Infinity]');
 ```
+
+#### bigint
+
+`bigint` strategy stringifies `BigInt` values as literals with a trailing `n`.
+
+```javascript
+var stringify = stringifier({
+    handlers: {
+        'bigint': s.bigint()
+    }
+});
+assert(stringify(BigInt('-100000000000000005')) === '-100000000000000005n');
 
 
 AUTHOR

--- a/index.js
+++ b/index.js
@@ -21,6 +21,7 @@ function defaultHandlers () {
     'string': s.json(),
     'boolean': s.json(),
     'number': s.number(),
+    'bigint': s.bigint(),
     'symbol': s.toStr(),
     'RegExp': s.toStr(),
     'String': s.newLike(),

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   },
   "semistandard": {
     "globals": [
+      "BigInt",
       "describe",
       "beforeEach",
       "it"

--- a/strategies.js
+++ b/strategies.js
@@ -315,6 +315,15 @@ const omitCircular = when(circular, compose(
 ));
 const omitMaxDepth = when(maxDepth, prune);
 
+function bigint () {
+  return (next) => {
+    return (acc, x) => {
+      acc.push(BigInt(x).toString() + 'n');
+      return next(acc, x);
+    };
+  };
+}
+
 module.exports = {
   filters: {
     always: always,
@@ -354,6 +363,7 @@ module.exports = {
       end()
     );
   },
+  bigint: () => compose(bigint(), end()),
   newLike: () => {
     return compose(
       always('new '),

--- a/test/various_types_test.js
+++ b/test/various_types_test.js
@@ -146,6 +146,13 @@ const fixtures = {
     pruned: 'undefined'
   }
 };
+if (typeof BigInt !== 'undefined') {
+  fixtures['bigint literal'] = {
+    input: BigInt('-100000000000000005'),
+    expected: '-100000000000000005n',
+    pruned: '-100000000000000005n'
+  };
+}
 if (typeof JSON !== 'undefined') {
   fixtures['JSON'] = {
     input: JSON,


### PR DESCRIPTION
`stringifier` currently can't print BigInt values, and will throw a mysterious error instead.

This is a problem when using [`power-assert`](https://github.com/power-assert-js/power-assert) to help test code that uses BigInts.